### PR TITLE
Add Databricks+Arcion to the documentation

### DIFF
--- a/themes/book/assets/_main.scss
+++ b/themes/book/assets/_main.scss
@@ -441,3 +441,15 @@ kbd {
     top: 1px;
   }
 }
+
+.banner {
+  position: fixed; 
+  z-index: 3;
+  width: 100%; 
+  text-align: center;
+  background-color:	#9370DB;
+}
+
+.banner-content { 
+  padding: 10px; 
+}

--- a/themes/book/layouts/404.html
+++ b/themes/book/layouts/404.html
@@ -29,7 +29,7 @@
     </main>
 
     {{ partial "docs/inject/body" . }}
-    {{ template "_internal/google_analytics_async.html" . }}
+    {{ template "_internal/google_analytics.html" . }}
   </body>
 
   </html>

--- a/themes/book/layouts/_default/baseof.html
+++ b/themes/book/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
 </head>
 
 <body dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
+  {{ partial "docs/banner" . }}
   <input type="checkbox" class="hidden toggle" id="menu-control" />
   <input type="checkbox" class="hidden toggle" id="toc-control" />
   <main class="container flex">

--- a/themes/book/layouts/partials/docs/banner.html
+++ b/themes/book/layouts/partials/docs/banner.html
@@ -1,0 +1,5 @@
+<div class="banner">
+    <div class="banner-content">
+        ✨ As of November 2023, Arcion has become a part of Databricks. <a href="https://www.databricks.com/blog/databricks-arcion-real-time-enterprise-data-replication-lakehouse">Learn more here</a> ✨
+    </div>
+</div>

--- a/themes/book/layouts/partials/docs/html-head.html
+++ b/themes/book/layouts/partials/docs/html-head.html
@@ -2,6 +2,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ default .Summary .Description }}">
 <meta name="theme-color" content="#FFFFFF">
+<meta name="robots" content="noindex">
 
 {{- template "_internal/opengraph.html" . -}}
 

--- a/themes/book/layouts/partials/docs/html-head.html
+++ b/themes/book/layouts/partials/docs/html-head.html
@@ -31,7 +31,7 @@
 <script defer src="{{ $swJS.RelPermalink }}" integrity="{{ $swJS.Data.Integrity }}"></script>
 {{ end -}}
 
-{{- template "_internal/google_analytics_async.html" . -}}
+{{- template "_internal/google_analytics.html" . -}}
 
 <!-- RSS -->
 {{- with .OutputFormats.Get "rss" -}}

--- a/themes/book/layouts/partials/docs/inject/toc-before.html
+++ b/themes/book/layouts/partials/docs/inject/toc-before.html
@@ -1,5 +1,0 @@
-<!-- <a class="cta-right-toc" href="https://www.arcion.io/contact">Contact us</a> -->
-<div class="cta">
-<a class="cta-right-toc self-hosted" href="https://www.arcion.io/contact">Get Arcion Self-hosted</a>
-<a class="cta-right-toc cloud" href="https://cloud.arcion.io/login">Get Arcion Cloud</a>
-</div>


### PR DESCRIPTION
As of November 2023, Arcion has become a part of Databricks. <a href="https://www.databricks.com/blog/databricks-arcion-real-time-enterprise-data-replication-lakehouse">Learn more here</a>

Preview:

<img width="1199" alt="Screenshot 2024-06-14 at 4 49 27 PM" src="https://github.com/arcionlabs/arcion-docs/assets/134318797/39bd7421-0dee-4680-ad6a-62b37c0e6b88">

This PR do the following:

- Fix a google analytics problem because of outdated `hugo` version
- Add `noindex` tag
- Add banner
- Remove Arcion self-hosted contacts