### PR TITLE
ACE-2438 Update native-oracle-log-reader.md

### DIFF
--- a/content/docs/sources/source-setup/Oracle/native-oracle-log-reader.md
+++ b/content/docs/sources/source-setup/Oracle/native-oracle-log-reader.md
@@ -94,7 +94,7 @@ Replicant supports using Oracle Automatic Storage Management (ASM) for logs. To 
     ...
 
     asm-connection:
-      host: //ASM_HOSTNAME
+      host: ASM_HOSTNAME
       port: 1521
       service-name: +ASM
       username: 'ASM_USERNAME'
@@ -104,7 +104,7 @@ Replicant supports using Oracle Automatic Storage Management (ASM) for logs. To 
 
     Replace the following:
 
-    - *`ASM_HOSTNAME`*: the hostname of the ASM instance. Make sure to prefix the hostname with `//`.
+    - *`ASM_HOSTNAME`*: the hostname of the ASM instance.
     - *`ASM_USERNAME`*: the username to connect to the ASM instance.
     - *`ASM_PASSWORD`*: the password associated with *`ASM_USERNAME`*.
 


### PR DESCRIPTION
Remove the mention of prefixing the hostname with // for ASM connection, it is no longer needed